### PR TITLE
import warnings

### DIFF
--- a/wurlitzer.py
+++ b/wurlitzer.py
@@ -22,6 +22,7 @@ import os
 import select
 import sys
 import threading
+import warnings
 
 libc = ctypes.CDLL(None)
 


### PR DESCRIPTION
caught  by `pyflakes`