### PR TITLE
Link blogpost about redirecting stdout/stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Capture C-level stdout/stderr pipes in Python via `os.dup2`.
 
+For more details on why this is needed, please read [this blog post]( https://eli.thegreenplace.net/2015/redirecting-all-kinds-of-stdout-in-python/ ).
+
 ## Install
 
     pip install wurlitzer


### PR DESCRIPTION
As not everyone may understand why it is tricky to redirect `stdout`/`stderr` from C in Python, link Eli Bendersky's blog post about why naive attempts to do this fail along with an explanation about what is happening at the system level and how to redirect C `stdout`/`stderr` correctly.

Have added this to the top section of the README, but am happy to move this around and/or change wording as preferred. Please let me know your thoughts. :)