### PR TITLE
select.poll timeout is in milliseconds

### DIFF
--- a/test.py
+++ b/test.py
@@ -57,6 +57,7 @@ def test_pipes_stderr():
         printf(u"Hellø")
         libc.fflush(c_stdout_p)
         printf_err(u"Hi, stdérr")
+        libc.fflush(c_stderr_p)
         assert _stdout is stdout
         assert _stderr is None
 

--- a/test.py
+++ b/test.py
@@ -56,8 +56,8 @@ def test_pipes_stderr():
     with pipes(stdout=stdout, stderr=STDOUT) as (_stdout, _stderr):
         printf(u"Hellø")
         libc.fflush(c_stdout_p)
+        time.sleep(0.1)
         printf_err(u"Hi, stdérr")
-        libc.fflush(c_stderr_p)
         assert _stdout is stdout
         assert _stderr is None
 

--- a/wurlitzer.py
+++ b/wurlitzer.py
@@ -181,7 +181,7 @@ class Wurlitzer(object):
                 poller.register(pipe_, select.POLLIN | select.POLLPRI)
 
             while pipes:
-                events = poller.poll(flush_interval)
+                events = poller.poll(int(flush_interval * 1000))
                 #r = all([(r_[1] == (select.POLLIN | select.POLLPRI)) for r_ in events])
                 if events:
                     # found something to read, don't block select until


### PR DESCRIPTION
select.select uses seconds, which is what self.flush_timeout used

I believe this is the cause of the occasional failures after switching to select.poll