### PR TITLE
flush sys streams on enter/exit

### DIFF
--- a/wurlitzer.py
+++ b/wurlitzer.py
@@ -181,8 +181,7 @@ class Wurlitzer(object):
                 msg = flush_queue.get()
                 if msg == 'stop':
                     return
-                libc.fflush(c_stdout_p)
-                libc.fflush(c_stderr_p)
+                self._flush()
 
         flush_thread = threading.Thread(target=flush_main)
         flush_thread.daemon = True


### PR DESCRIPTION
not just low-level streams

ensures captured sys/stdout are flushed prior to stopping capture/redirect.

I think this closes #37 