### PR TITLE
explicitly close the poller when we are done with it

### DIFF
--- a/wurlitzer.py
+++ b/wurlitzer.py
@@ -242,6 +242,7 @@ class Wurlitzer(object):
             flush_thread.join()
             # cleanup pipes
             [os.close(pipe) for pipe in pipes]
+            poller.close()
 
         self.thread = threading.Thread(target=forwarder)
         self.thread.daemon = True


### PR DESCRIPTION
the poller has an FD associated with it

relying on garbage collection meant it wouldn't be closed until `gc.collect()` is called

closes #46 