### PR TITLE
import F_GETPIPE_SZ along with F_SETPIPE_SZ

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,9 @@ name: Release
 # but only publish to PyPI on tags
 on:
   push:
+    tags:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,8 @@ name: Test
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   pre-commit:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10.0-rc.1"
         include:
           - os: macos-latest
             python: 3.8

--- a/wurlitzer.py
+++ b/wurlitzer.py
@@ -30,7 +30,7 @@ from functools import lru_cache
 from queue import Queue
 
 try:
-    from fcntl import F_SETPIPE_SZ
+    from fcntl import F_GETPIPE_SZ, F_SETPIPE_SZ
 except ImportError:
     # ref: linux uapi/linux/fcntl.h
     F_SETPIPE_SZ = 1024 + 7


### PR DESCRIPTION
fixes tests on 3.10, which defines these symbols (closes #53)