### PR TITLE
Bump pre-commit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,13 +7,6 @@ on:
       - main
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
-
   test:
     runs-on: ${{ matrix.os }}
 
@@ -29,7 +22,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10.0-rc.1"
+          - "3.10"
         include:
           - os: macos-latest
             python: 3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.3
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.5.1
     hooks:
       - id: prettier
   - repo: https://gitlab.com/pycqa/flake8
-    rev: "3.8.4"
+    rev: "3.9.2"
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
       - id: end-of-file-fixer
       - id: check-case-conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ profile = "black"
 [tool.black]
 skip-string-normalization = true
 target_version = [
-    "py27",
+    "py35",
     "py36",
     "py37",
     "py38",


### PR DESCRIPTION
- bump pre-commit hook versions
- run pre-commit on pre-commit.ci instead of GHA
- bump target black version to 3.5, the minimum supported actual target