### PR TITLE
Include STDOUT and PIPE in public API

### DIFF
--- a/wurlitzer.py
+++ b/wurlitzer.py
@@ -11,6 +11,8 @@ __all__ = [
     'sys_pipes',
     'sys_pipes_forever',
     'stop_sys_pipes',
+    'PIPE',
+    'STDOUT',
     'Wurlitzer',
 ]
 


### PR DESCRIPTION
Include STDOUT and PIPE in the public API as the documentation recommends their use.

This will mean linters do not produce warnings like the following:
```
'STDOUT' is not declared in __all__ 
```

Examples from the documentation recommending the used of `STDOUT` and `PIPE`:

`Demo.ipynb`:

```python
from wurlitzer import pipes, sys_pipes, STDOUT, PIPE
```

`README.md`:

```python
from wurlitzer import pipes, STDOUT
```