### PR TITLE
Update `pipes`'s docstring

### DIFF
--- a/wurlitzer.py
+++ b/wurlitzer.py
@@ -390,7 +390,7 @@ def pipes(stdout=PIPE, stderr=PIPE, encoding=_default_encoding, bufsize=None):
     Examples
     --------
 
-    >>> with capture() as (stdout, stderr):
+    >>> with pipes() as (stdout, stderr):
     ...     printf("C-level stdout")
     ... output = stdout.read()
     """


### PR DESCRIPTION
The example in the docstring for the `pipes` context manager still uses the old `capture` name, this PR fixes this.

I'm taking advantage of this PR to mention that I've opened [a PR on typeshed](https://github.com/python/typeshed/pull/11459) to add typing for this package.
